### PR TITLE
Update connection.js Fix ReplyError: NOAUTH Authentication required.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -133,7 +133,8 @@ Connection.prototype.connectRedis = function (config, callback) {
     port: config.port,
     host: config.host,
     enableReadyCheck: true,
-    showFriendlyErrorStack: true
+    showFriendlyErrorStack: true,
+    password: config.redis_auth
   })
   if (config.redis_auth) {
     client.auth(config.redis_auth)


### PR DESCRIPTION
connectRedis throws an exception.

ReplyError: NOAUTH Authentication required.

The redis password should be supplied in a password property.

See 
Line 71 of https://github.com/luin/ioredis/blob/v4.28.5/lib/redis/RedisOptions.ts

### Description

Describe the original problem and the changes made on this PR.

### References

* Jira:
* Github issue:

### Risks

* High | Medium | Low : How might failures be experienced? All code changes
  carry a minimum of risk of **Low**, and **None** should be a rare exception.
* Rollback:
